### PR TITLE
Add CLI Command Help

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -19,6 +19,7 @@ const
 	JSON_REPLACER = 0,
 	JSON_SPACE = 2;
 
+	// There has to be a better way to do this...
 	// eslint-disable-next-line no-sync
 	md = markdown.parse(fs.readFileSync('./readme.md', 'utf8'));
 
@@ -97,10 +98,12 @@ module.exports = (function (app) {
 
 		// show command specific help...
 		if (showHelp) {
+			// find the documentation index of the command and its parameters
 			const commandIndex = md.findIndex(findCommand, app.args.command);
-			const description = md[commandIndex+1][1];
 			const usageIndex = md.findIndex(findUsage, [app.args.api, app.args.command]);
+			const description = md[commandIndex+1][1];
 			const parameters = md[usageIndex][3][1].match(/\((.*?)\)/)[1].split(', ');
+
 			console.log([
 				`#${app.args.command}: '${description}'`,
 				'Usage:',
@@ -112,11 +115,13 @@ module.exports = (function (app) {
 		}
 	}
 
+	// lookup command in docs w/ JSONML structure
 	function findCommand (element) {
 		// eslint-disable-next-line no-magic-numbers, no-invalid-this
 		return (element[0] === 'header' && element[1].level === 4 && element[2] === `#${this}`);
 	}
 
+	// lookup usage in docs w/ JSONML structure
 	function findUsage (element) {
 		// eslint-disable-next-line no-magic-numbers, no-invalid-this
 		return (element[0] === 'para' && element[1][1] === 'Usage:' && element[3][0] === 'inlinecode' && element[3][1].startsWith(`client.${this[0]}.${this[1]}`));

--- a/cli/index.js
+++ b/cli/index.js
@@ -97,22 +97,29 @@ module.exports = (function (app) {
 
 		// show command specific help...
 		if (showHelp) {
-			let index = md.findIndex(getCommandIndex);
-			let description = md[index+1][1];
-			let params = md[index+3];
-			console.log(params);
+			const commandIndex = md.findIndex(findCommand, app.args.command);
+			const description = md[commandIndex+1][1];
+			const usageIndex = md.findIndex(findUsage, [app.args.api, app.args.command]);
+			const parameters = md[usageIndex][3][1].match(/\((.*?)\)/)[1].split(', ');
 			console.log([
-				`#${app.args.command}: ${description}`,
-				`Usage: ${params}`
+				`#${app.args.command}: '${description}'`,
+				'Usage:',
+				`	${app.args.program} -a ${app.args.api} -c ${app.args.command} <${parameters}>`,
+				''
 			].join(os.EOL));
 
 			process.exit();
 		}
 	}
 
-	function getCommandIndex(element) {
-		// eslint-disable-next-line no-magic-numbers
-		return (element[0] === 'header' && element[1].level === 4 && element[2] === `#${app.args.command}`);
+	function findCommand (element) {
+		// eslint-disable-next-line no-magic-numbers, no-invalid-this
+		return (element[0] === 'header' && element[1].level === 4 && element[2] === `#${this}`);
+	}
+
+	function findUsage (element) {
+		// eslint-disable-next-line no-magic-numbers, no-invalid-this
+		return (element[0] === 'para' && element[1][1] === 'Usage:' && element[3][0] === 'inlinecode' && element[3][1].startsWith(`client.${this[0]}.${this[1]}`));
 	}
 
 	function parsePipeData () {

--- a/cli/index.js
+++ b/cli/index.js
@@ -2,8 +2,10 @@
 const
 	os = require('os'),
 	stream = require('stream'),
+	fs = require('fs'),
 
 	co = require('co'),
+	markdown = require('markdown').markdown,
 
 	lib = require('../lib'),
 	nodePackage = require('../package.json'),
@@ -17,6 +19,8 @@ const
 	JSON_REPLACER = 0,
 	JSON_SPACE = 2;
 
+	// eslint-disable-next-line no-sync
+	md = markdown.parse(fs.readFileSync('./readme.md', 'utf8'));
 
 module.exports = (function (app) {
 	'use strict';
@@ -39,7 +43,7 @@ module.exports = (function (app) {
 				app.args.commandArgs = args.slice(COMMAND_ARGS_START + index);
 
 				// stop processing command inputs
-				return true;
+				return false;
 			}
 
 			if (ARGS_HELP_RE.test(arg)) {
@@ -93,8 +97,22 @@ module.exports = (function (app) {
 
 		// show command specific help...
 		if (showHelp) {
-			// TODO: build support for command specific help
+			let index = md.findIndex(getCommandIndex);
+			let description = md[index+1][1];
+			let params = md[index+3];
+			console.log(params);
+			console.log([
+				`#${app.args.command}: ${description}`,
+				`Usage: ${params}`
+			].join(os.EOL));
+
+			process.exit();
 		}
+	}
+
+	function getCommandIndex(element) {
+		// eslint-disable-next-line no-magic-numbers
+		return (element[0] === 'header' && element[1].level === 4 && element[2] === `#${app.args.command}`);
 	}
 
 	function parsePipeData () {

--- a/cli/index.js
+++ b/cli/index.js
@@ -19,10 +19,6 @@ const
 	JSON_REPLACER = 0,
 	JSON_SPACE = 2;
 
-	// There has to be a better way to do this...
-	// eslint-disable-next-line no-sync
-	md = markdown.parse(fs.readFileSync('./readme.md', 'utf8'));
-
 module.exports = (function (app) {
 	'use strict';
 
@@ -98,6 +94,11 @@ module.exports = (function (app) {
 
 		// show command specific help...
 		if (showHelp) {
+			// There has to be a better way to do this...
+			// Convert documentation to JSONML
+			// eslint-disable-next-line no-sync
+			const md = markdown.parse(fs.readFileSync('./readme.md', 'utf8'));
+
 			// find the documentation index of the command and its parameters
 			const commandIndex = md.findIndex(findCommand, app.args.command);
 			const usageIndex = md.findIndex(findUsage, [app.args.api, app.args.command]);

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
       "url": "https://github.com/cmerchant"
     },
     {
-	  "name": "Deepak Dahal",
-	  "url": "https://github.com/deepakdahal"
+      "name": "Deepak Dahal",
+      "url": "https://github.com/deepakdahal"
     }
   ],
   "description": "SDK to make accessing PlayNetwork APIs when writing code in Javascript (Node.js) much easier.",
@@ -69,6 +69,7 @@
   },
   "dependencies": {
     "co": "^4.6.0",
+    "markdown": "^0.5.0",
     "socket.io-client": "^2.0.3"
   }
 }


### PR DESCRIPTION
This could use some hardcore review!
My naive attempt to tackle the `TODO: show command specific help`:

- Using a lib to parse README.md to JSONML
- If help command is passed, traverse JSONML to find command documentation
- Pull description and parameters from documentation
- Print command specific info
- Exit execution
