### PR TITLE
BMS-8 Enables request pool

### DIFF
--- a/history.md
+++ b/history.md
@@ -1,3 +1,7 @@
+# v2.2.3 - 2019/03/27
+
+Enables the use of a request pool for all requests
+
 # v2.2.2 - 2019/03/06
 
 * Added support for filtering out assets that don't exist

--- a/lib/asset.js
+++ b/lib/asset.js
@@ -119,7 +119,7 @@ module.exports = function (assetOptions, ensureAuthHeaders, self) {
 			asset = undefined;
 			options = undefined;
 		}
-		
+
 		let exec = co(function *() {
 			if (validation.isEmpty(asset)) {
 				return yield Promise.reject(new Error('asset is required'));
@@ -211,7 +211,6 @@ module.exports = function (assetOptions, ensureAuthHeaders, self) {
 		// handle any non-specified input params
 		if (typeof assets === 'function') {
 			callback = assets;
-			original = undefined;
 		}
 
 		let exec = co(function *() {

--- a/lib/http-agent.js
+++ b/lib/http-agent.js
@@ -1,0 +1,82 @@
+/**
+ * This module limits the created of http.Agent instances to only one that
+ * allows connection pooling and another one that does not.
+ * The agents will be created on demand the first time and then the instances
+ * will be returned on subsequent calls to the getAgent method.
+ */
+const http = require('http');
+const https = require('https');
+
+const DEFAULT_KEEP_ALIVE_MSECS = 60000;
+const DEFAULT_KEEP_ALIVE_MAX_SOCKETS = 32;
+const DEFAULT_KEEP_ALIVE_MAX_FREE_SOCKETS = 32;
+
+let keepAliveAgent;
+let defaultAgent;
+
+/**
+ * Retuns a new instance of the http.Agent
+ * @param {Boolean} isSecure is https?
+ * @param {Object} [options] can contain
+ *  - options.keepAlive {Boolean}
+ *  - options.keepAliveMsecs {Integer}
+ *  - options.maxSockets  {Integer}
+ *  - options.maxFreeSockets {Integer}
+ *
+ * @returns {http.Agent} Agent
+ */
+function createAgent(isSecure, options = {}) {
+	return new (isSecure ? https : http).Agent(options);
+}
+
+/**
+ * Returns an instance of the 'keep-alive' http.Agent that _ALLOWS_ connection
+ * pooling
+ * It will create a new instance only the first time is invoked
+ * @param {Boolean} isSecure is https?
+ *
+ * @returns {http.Agent} Agent
+ */
+function getKeepAliveAgent(isSecure) {
+	if (!keepAliveAgent) {
+		keepAliveAgent = createAgent(isSecure, {
+			keepAlive: true,
+			keepAliveMsecs: DEFAULT_KEEP_ALIVE_MSECS,
+			maxSockets: DEFAULT_KEEP_ALIVE_MAX_SOCKETS,
+			maxFreeSockets: DEFAULT_KEEP_ALIVE_MAX_FREE_SOCKETS
+		});
+	}
+
+	return keepAliveAgent;
+}
+
+/**
+ * Returns an instance of the default http.Agent that _DOES_NOT_ allow
+ * connection pooling
+ * It will create a new instance only the first time is invoked
+ * @param {Boolean} isSecure is https?
+ *
+ * @returns {http.Agent} Agent
+ */
+function getDefaultAgent(isSecure) {
+	if (!defaultAgent) {
+		defaultAgent = createAgent(isSecure);
+	}
+
+	return defaultAgent;
+	}
+
+	module.exports = {
+	/**
+	 * Returns the appropriate agent depending on the specified params
+	 * @param {Boolean} isSecure is https?
+	 * @param {Bollean} allowPooling should we keep connection alive?
+	 *
+	 * @returns {http.Agent} Agent
+	 */
+	getAgent: function (isSecure, allowPooling) {
+		return allowPooling ?
+			getKeepAliveAgent(isSecure) :
+			getDefaultAgent(isSecure);
+	}
+};

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,6 +1,7 @@
 var
 	events = require('events'),
 	http = require('http'),
+	httpAgent = require('./http-agent'),
 	https = require('https'),
 	qs = require('querystring'),
 	url = require('url'),
@@ -172,6 +173,11 @@ module.exports = (function (self) {
 					augmented.keepAliveMsecs,
 					DEFAULT_KEEP_ALIVE_MSECS);
 
+				augmented.agent = httpAgent.getAgent(
+					augmented.secure,
+					augmented.keepAlive
+				);
+
 				// create `path` from pathname and query.
 				augmented.path = validation.coalesce(
 					augmented.path,
@@ -217,13 +223,6 @@ module.exports = (function (self) {
 				options = augmentRequestOptions(options);
 				options.headers = options.headers || {};
 				tryCount = tryCount || FIRST_TRY;
-
-				if (options.keepAlive) {
-					options.agent = new (options.secure ? https : http).Agent({
-						keepAlive: options.keepAlive,
-						keepAliveMsecs: options.keepAliveMsecs
-					});
-				}
 
 				let
 					exec,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playnetwork-sdk",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "contributors": [
     {
       "name": "Joshua Thomas",

--- a/test/lib/http-agent.js
+++ b/test/lib/http-agent.js
@@ -1,0 +1,87 @@
+/*eslint no-magic-numbers: 0*/
+/*eslint no-unused-expressions: 0*/
+const { expect } = require('chai');
+const httpAgent = require('../../lib/http-agent');
+
+describe('http-agent', () => {
+	describe('connection pooling', () => {
+		describe('https', () => {
+			it('should allow connection pooling', () => {
+				const isSecure = true;
+				const allowPooling = true;
+				const agent = httpAgent.getAgent(isSecure, allowPooling);
+
+				// agent must allow connection pooling
+				expect(agent.options.keepAlive).to.be.true;
+			});
+
+			it('should _not_ allow connection pooling', () => {
+				const isSecure = true;
+				const allowPooling = false;
+				const agent = httpAgent.getAgent(isSecure, allowPooling);
+
+				// if connection pooling is disabled then the keep alive field
+				// will not exist
+				expect(agent.options.keepAlive).to.be.undefined;
+			});
+		});
+
+		describe('http', () => {
+			it('should allow connection pooling', () => {
+				const isSecure = false;
+				const allowPooling = true;
+				const agent = httpAgent.getAgent(isSecure, allowPooling);
+
+				// agent must allow connection pooling
+				expect(agent.options.keepAlive).to.be.true;
+			});
+
+			it('should _not_ allow connection pooling', () => {
+				const isSecure = false;
+				const allowPooling = false;
+				const agent = httpAgent.getAgent(isSecure, allowPooling);
+
+				// if connection pooling is disabled then the keep alive field
+				// will not exist
+				expect(agent.options.keepAlive).to.be.undefined;
+			});
+		});
+	});
+
+	describe('agents should be reused', () => {
+		it('should reuse https agent', () => {
+			const maxIterations = 5;
+			const isSecure = true;
+			const allowPooling = true;
+			// get agent that should be reused
+			const agent = httpAgent.getAgent(isSecure, allowPooling);
+
+			// set a dummy param so that we can verify that next time the same
+			// agent is returned.
+			agent.foo = true;
+
+			for (let i = 0; i < maxIterations; i++) {
+				let fooAgent = httpAgent.getAgent(isSecure, allowPooling);
+				expect(fooAgent.foo).to.be.true;
+			}
+
+		});
+
+		it('should reuse http agent', () => {
+			const maxIterations = 5;
+			const isSecure = false;
+			const allowPooling = true;
+
+			// get agent that should be reused
+			const agent = httpAgent.getAgent(isSecure, allowPooling);
+			// set a dummy param so that we can verify that next time the same
+			// agent is returned.
+			agent.foo = true;
+
+			for (let i = 0; i < maxIterations; i++) {
+				let fooAgent = httpAgent.getAgent(isSecure, allowPooling);
+				expect(fooAgent.foo).to.be.true;
+			}
+		});
+	});
+});


### PR DESCRIPTION
This changeset allows reusing a http agent which results
in using a request pool for requests.

----------------

all the http-agent related code was copied from the develop branch as I had already added the changes to that branch.