### PR TITLE
BMSMP-184: Handle JSON.parse failure

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -98,10 +98,14 @@ module.exports = function (playerOptions, ensureAuthHeaders, self) {
 		});
 
 		socket.on('error', (err) => {
-			err = JSON.parse(err);
+			try {
+				err = JSON.parse(err);
+			} catch (e) {
+				err = e;
+			}
 			socketEventSubscriber.emit('error', err);
 
-			if (err.code === AUTH_ERROR) { 
+			if (err.code === AUTH_ERROR) {
 				socket.disconnect();
 
 				// reconnect if failed during authorization

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "playnetwork-sdk",
-  "version": "1.4.5",
+  "version": "1.4.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playnetwork-sdk",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "contributors": [
     {
       "name": "Joshua Thomas",


### PR DESCRIPTION
Sometimes an `Error` is emitted, which cannot be parsed with `JSON.parse`, in which case an error is thrown.

Closes [BMSMP-184](https://jira.touchtunes.com/browse/BMSMP-184).