### PR TITLE
BMS-448: Fixed the bug which wouldn't activate exponential backoff mechanism

### DIFF
--- a/history.md
+++ b/history.md
@@ -1,3 +1,7 @@
+# v2.2.7 - 2020/02/19
+
+* Added backoff mechanism to any request called with setting totalTimeout.
+
 # v2.2.6 - 2020/01/08
 
 * Added backoff mechanism to any request called with setting totalTimeout.

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -32,6 +32,14 @@ module.exports = (function (self) {
 			outputOptions.timeout = parseInt(inputOptions.timeout, 10);
 		}
 
+		if (!self.isEmpty(inputOptions.totalTimeout) && !isNaN(inputOptions.totalTimeout)) {
+			outputOptions.totalTimeout = parseInt(inputOptions.totalTimeout, 10);
+		}
+
+		if (!self.isEmpty(inputOptions.initialDelay) && !isNaN(inputOptions.initialDelay)) {
+			outputOptions.initialDelay = parseInt(inputOptions.initialDelay, 10);
+		}
+
 		return outputOptions;
 	};
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "playnetwork-sdk",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playnetwork-sdk",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "contributors": [
     {
       "name": "Joshua Thomas",

--- a/test/lib/validation.js
+++ b/test/lib/validation.js
@@ -31,7 +31,9 @@ describe('validation', () => {
 					port : 8080,
 					rejectUnauthorized : true,
 					secure : true,
-					timeout : 60000
+					timeout : 60000,
+					totalTimeout: 5000,
+					initialDelay: 50
 				},
 				outputOptions = validation.applyOptionalParameters(inputOptions);
 
@@ -45,6 +47,10 @@ describe('validation', () => {
 			outputOptions.rejectUnauthorized.should.equal(true);
 			outputOptions.should.have.property('timeout');
 			outputOptions.timeout.should.equal(60000);
+			outputOptions.should.have.property('totalTimeout');
+			outputOptions.totalTimeout.should.equal(5000);
+			outputOptions.should.have.property('initialDelay');
+			outputOptions.initialDelay.should.equal(50);
 
 			should.not.exist(outputOptions.host);
 			should.not.exist(outputOptions.secure);
@@ -81,6 +87,9 @@ describe('validation', () => {
 			outputOptions.secure.should.equal(true);
 			outputOptions.should.have.property('timeout');
 			outputOptions.timeout.should.equal(60000);
+
+			should.not.exist(outputOptions.totalTimeout);
+			should.not.exist(outputOptions.initialDelay);
 		});
 	});
 


### PR DESCRIPTION
This is a bug even if client uses the totalTimeout field, it wouldn't activate exponential backoff mechanism.

I have manually tested couple of APIs after this fix it worked for those.