### PR TITLE
Add method to parse host, port, and protocol from URL

### DIFF
--- a/lib/asset.js
+++ b/lib/asset.js
@@ -4,6 +4,7 @@ var
 	co = require('co'),
 
 	request = require('./request'),
+	url = require('./url'),
 	validation = require('./validation');
 
 const
@@ -40,6 +41,13 @@ module.exports = function (assetOptions, ensureAuthHeaders, self) {
 
 	// apply additional optional settings if supplied
 	settings = validation.applyOptionalParameters(assetOptions, settings);
+
+	const result = url.parseURL(settings.host);
+	if (!validation.isEmpty(result)) {
+		settings.host = result.host;
+		settings.port = result.port;
+		settings.secure = result.secure;
+	}
 
 	// ensure request is setup
 	req = new request.Request(settings);

--- a/lib/campaign.js
+++ b/lib/campaign.js
@@ -4,6 +4,7 @@ var
 	co = require('co'),
 	fs = require('fs'),
 	request = require('./request'),
+	url = require('./url'),
 	validation = require('./validation');
 
 const
@@ -39,6 +40,13 @@ module.exports = function (campaignOptions, ensureAuthHeaders, self) {
 
 	// apply additional optional settings if supplied
 	settings = validation.applyOptionalParameters(campaignOptions, settings);
+
+	const result = url.parseURL(settings.host);
+	if (!validation.isEmpty(result)) {
+		settings.host = result.host;
+		settings.port = result.port;
+		settings.secure = result.secure;
+	}
 
 	// ensure request is setup
 	req = new request.Request(settings);

--- a/lib/claim.js
+++ b/lib/claim.js
@@ -4,6 +4,7 @@ var
 	co = require('co'),
 
 	request = require('./request'),
+	url = require('./url'),
 	validation = require('./validation');
 
 const
@@ -38,6 +39,13 @@ module.exports = function (claimOptions, ensureAuthHeaders, self) {
 
 	// apply additional optional settings if supplied
 	settings = validation.applyOptionalParameters(claimOptions, settings);
+
+	const result = url.parseURL(settings.host);
+	if (!validation.isEmpty(result)) {
+		settings.host = result.host;
+		settings.port = result.port;
+		settings.secure = result.secure;
+	}
 
 	// ensure request is setup
 	req = new request.Request(settings);

--- a/lib/content.js
+++ b/lib/content.js
@@ -5,6 +5,7 @@ var
 	co = require('co'),
 
 	request = require('./request'),
+	url = require('./url'),
 	validation = require('./validation');
 
 const
@@ -44,6 +45,13 @@ module.exports = function (contentOptions, ensureAuthHeaders, self) {
 
 	// apply additional optional settings if supplied
 	settings = validation.applyOptionalParameters(contentOptions, settings);
+
+	const result = url.parseURL(settings.host);
+	if (!validation.isEmpty(result)) {
+		settings.host = result.host;
+		settings.port = result.port;
+		settings.secure = result.secure;
+	}
 
 	// ensure request is setup
 	req = new request.Request(settings);

--- a/lib/device.js
+++ b/lib/device.js
@@ -4,6 +4,7 @@ var
 	co = require('co'),
 
 	request = require('./request'),
+	url = require('./url'),
 	validation = require('./validation');
 
 const
@@ -40,6 +41,13 @@ module.exports = function (deviceOptions, ensureAuthHeaders, self) {
 
 	// apply additional optional settings if supplied
 	settings = validation.applyOptionalParameters(deviceOptions, settings);
+
+	const result = url.parseURL(settings.host);
+	if (!validation.isEmpty(result)) {
+		settings.host = result.host;
+		settings.port = result.port;
+		settings.secure = result.secure;
+	}
 
 	// ensure request is setup
 	req = new request.Request(settings);

--- a/lib/key.js
+++ b/lib/key.js
@@ -6,6 +6,7 @@ var
 	co = require('co'),
 
 	request = require('./request'),
+	url = require('./url'),
 	validation = require('./validation');
 
 const
@@ -57,6 +58,13 @@ module.exports = function (keyOptions, clientId, secret, self) {
 
 	// apply additional optional settings if supplied
 	settings = validation.applyOptionalParameters(keyOptions, settings);
+
+	const result = url.parseURL(settings.host);
+	if (!validation.isEmpty(result)) {
+		settings.host = result.host;
+		settings.port = result.port;
+		settings.secure = result.secure;
+	}
 
 	// ensure request is setup
 	req = new request.Request(settings);

--- a/lib/location.js
+++ b/lib/location.js
@@ -4,6 +4,7 @@ var
 	co = require('co'),
 
 	request = require('./request'),
+	url = require('./url'),
 	validation = require('./validation');
 
 const
@@ -38,6 +39,13 @@ module.exports = function (locationOptions, ensureAuthHeaders, self) {
 
 	// apply additional optional settings if supplied
 	settings = validation.applyOptionalParameters(locationOptions, settings);
+
+	const result = url.parseURL(settings.host);
+	if (!validation.isEmpty(result)) {
+		settings.host = result.host;
+		settings.port = result.port;
+		settings.secure = result.secure;
+	}
 
 	// ensure request is setup
 	req = new request.Request(settings);

--- a/lib/music.js
+++ b/lib/music.js
@@ -4,6 +4,7 @@ var
 	co = require('co'),
 
 	request = require('./request'),
+	url = require('./url'),
 	validation = require('./validation');
 
 const
@@ -42,6 +43,13 @@ module.exports = function (musicOptions, ensureAuthHeaders, self) {
 
 	// apply additional optional settings if supplied
 	settings = validation.applyOptionalParameters(musicOptions, settings);
+
+	const result = url.parseURL(settings.host);
+	if (!validation.isEmpty(result)) {
+		settings.host = result.host;
+		settings.port = result.port;
+		settings.secure = result.secure;
+	}
 
 	// ensure request is setup
 	req = new request.Request(settings);

--- a/lib/playback.js
+++ b/lib/playback.js
@@ -4,6 +4,7 @@ var
 	co = require('co'),
 
 	request = require('./request'),
+	url = require('./url'),
 	validation = require('./validation');
 
 const
@@ -38,6 +39,13 @@ module.exports = function (playbackOptions, ensureAuthHeaders, self) {
 
 	// apply additional optional settings if supplied
 	settings = validation.applyOptionalParameters(playbackOptions, settings);
+
+	const result = url.parseURL(settings.host);
+	if (!validation.isEmpty(result)) {
+		settings.host = result.host;
+		settings.port = result.port;
+		settings.secure = result.secure;
+	}
 
 	// ensure request is setup
 	req = new request.Request(settings);

--- a/lib/player.js
+++ b/lib/player.js
@@ -2,6 +2,7 @@ var
 	co = require('co'),
 	events = require('events'),
 	io = require('socket.io-client'),
+	url = require('./url'),
 	validation = require('./validation');
 
 let
@@ -45,6 +46,13 @@ module.exports = function (playerOptions, ensureAuthHeaders, self) {
 
 	// apply additional optional settings if supplied
 	settings = validation.applyOptionalParameters(playerOptions, settings);
+
+	const result = url.parseURL(settings.host);
+	if (!validation.isEmpty(result)) {
+		settings.host = result.host;
+		settings.port = result.port;
+		settings.secure = result.secure;
+	}
 
 	self.settings = () => (settings);
 

--- a/lib/provision.js
+++ b/lib/provision.js
@@ -4,6 +4,7 @@ var
 	co = require('co'),
 
 	request = require('./request'),
+	url = require('./url'),
 	validation = require('./validation');
 
 const
@@ -41,6 +42,13 @@ module.exports = function (provisionOptions, ensureAuthHeaders, self) {
 
 	// apply additional optional settings if supplied
 	settings = validation.applyOptionalParameters(provisionOptions, settings);
+
+	const result = url.parseURL(settings.host);
+	if (!validation.isEmpty(result)) {
+		settings.host = result.host;
+		settings.port = result.port;
+		settings.secure = result.secure;
+	}
 
 	// ensure request is setup
 	req = new request.Request(settings);

--- a/lib/relationship.js
+++ b/lib/relationship.js
@@ -4,6 +4,7 @@ var
 	co = require('co'),
 
 	request = require('./request'),
+	url = require('./url'),
 	validation = require('./validation');
 
 const
@@ -38,6 +39,13 @@ module.exports = function (relationshipsOptions, ensureAuthHeaders, self) {
 
 	// apply additional optional settings if supplied
 	settings = validation.applyOptionalParameters(relationshipsOptions, settings);
+
+	const result = url.parseURL(settings.host);
+	if (!validation.isEmpty(result)) {
+		settings.host = result.host;
+		settings.port = result.port;
+		settings.secure = result.secure;
+	}
 
 	// ensure request is setup
 	req = new request.Request(settings);

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -4,6 +4,7 @@ var
 	co = require('co'),
 
 	request = require('./request'),
+	url = require('./url'),
 	validation = require('./validation');
 
 const
@@ -38,6 +39,13 @@ module.exports = function (settingsOptions, ensureAuthHeaders, self) {
 
 	// apply additional optional settings if supplied
 	settings = validation.applyOptionalParameters(settingsOptions, settings);
+
+	const result = url.parseURL(settings.host);
+	if (!validation.isEmpty(result)) {
+		settings.host = result.host;
+		settings.port = result.port;
+		settings.secure = result.secure;
+	}
 
 	// ensure request is setup
 	req = new request.Request(settings);

--- a/lib/url.js
+++ b/lib/url.js
@@ -1,0 +1,33 @@
+const { URL } = require('url');
+
+/**
+ * Parse the input (URL string) to get its hostname, port, and protocol.
+ * In the case that it's not parsable and it throws an error, return the an empty object.
+ * We do this to preserve backward compatibility.
+ * Note: this method assumes you are using either HTTP or HTTPS protocols.
+ * @param   {String}    input   The URL.
+ * @param   {Object}    output  An object containing host, port, and secure properties.
+ * @returns {Object}    The object containing valid host, port, and secure keys based on the input.
+ */
+const parseURL = (input) => {
+  const output = {};
+
+  let url;
+  try {
+    url = new URL(input);
+  } catch (e) {
+    return output;
+  }
+
+  const { hostname, port, protocol } = url;
+
+  output.host = hostname;
+  output.port = port;
+  output.secure = protocol === 'https:';
+
+  return output;
+};
+
+module.exports = {
+  parseURL
+};

--- a/lib/url.js
+++ b/lib/url.js
@@ -1,16 +1,32 @@
 const { URL } = require('url');
 
+const PROTOCOL_HTTP = 'http:';
+const PROTOCOL_HTTPS = 'https:';
+
 /**
  * Parse the input (URL string) to get its hostname, port, and protocol.
- * In the case that it's not parsable and it throws an error, return the an empty object.
+ * In the case that it's not parsable and it throws an error, return an empty object.
  * We do this to preserve backward compatibility.
- * Note: this method assumes you are using either HTTP or HTTPS protocols.
+ * Note: this method assumes you are using either HTTP or HTTPS protocols. It assumes HTTPS if protocol isn't provided.
  * @param   {String}    input   The URL.
  * @param   {Object}    output  An object containing host, port, and secure properties.
  * @returns {Object}    The object containing valid host, port, and secure keys based on the input.
  */
 const parseURL = (input) => {
   const output = {};
+
+  if (typeof(input) !== 'string') {
+    return output;
+  }
+
+  input = input.trim();
+  if (input === '') {
+    return output;
+  }
+
+  if (!input.startsWith(PROTOCOL_HTTP) && !input.startsWith(PROTOCOL_HTTPS)) {
+    input = PROTOCOL_HTTPS + input;
+  }
 
   let url;
   try {
@@ -23,7 +39,7 @@ const parseURL = (input) => {
 
   output.host = hostname;
   output.port = port;
-  output.secure = protocol === 'https:';
+  output.secure = protocol === PROTOCOL_HTTPS;
 
   return output;
 };

--- a/test/lib/url.js
+++ b/test/lib/url.js
@@ -3,22 +3,62 @@
 const url = require('../../lib/url');
 
 describe('validation', () => {
-	describe('#parseURL', function() {
-		it('should return an object with host, port, and secure keys', function() {
-			let result = url.parseURL('http://localhost:3000');
-			result.host.should.equal('localhost');
-			result.port.should.equal('3000');
-			result.secure.should.be.false;
+  describe('#parseURL', function() {
+    it('should return an object with host, port, and secure keys', function() {
+      let result = url.parseURL('http://localhost:3000');
+      result.host.should.equal('localhost');
+      result.port.should.equal('3000');
+      result.secure.should.be.false;
 
-			result = url.parseURL('https://localhost');
-			result.host.should.equal('localhost');
-			result.port.should.equal('');
-			result.secure.should.be.true;
+      result = url.parseURL('https://localhost');
+      result.host.should.equal('localhost');
+      result.port.should.equal('');
+      result.secure.should.be.true;
 
-			result = url.parseURL('https://example.com:12345');
-			result.host.should.equal('example.com');
-			result.port.should.equal('12345');
-			result.secure.should.be.true;
-		});
-	});
+      result = url.parseURL('https://example.com:12345');
+      result.host.should.equal('example.com');
+      result.port.should.equal('12345');
+      result.secure.should.be.true;
+
+      result = url.parseURL('');
+      result.should.deep.equal({});
+
+      result = url.parseURL(null);
+      result.should.deep.equal({});
+    });
+
+    it('should return an empty object on invalid input', function() {
+      let result = url.parseURL('');
+      result.should.deep.equal({});
+
+      result = url.parseURL('             ');
+      result.should.deep.equal({});
+
+      result = url.parseURL('this is not a url');
+      result.should.deep.equal({});
+
+      result = url.parseURL(':8080');
+      result.should.deep.equal({});
+
+      result = url.parseURL(null);
+      result.should.deep.equal({});
+    });
+
+    it('assumes secure protocol if it is not provided in the url', function() {
+      let result = url.parseURL('example.com:12345');
+      result.host.should.equal('example.com');
+      result.port.should.equal('12345');
+      result.secure.should.be.true;
+
+      result = url.parseURL('localhost');
+      result.host.should.equal('localhost');
+      result.port.should.equal('');
+      result.secure.should.be.true;
+
+      result = url.parseURL('127.0.0.1');
+      result.host.should.equal('127.0.0.1');
+      result.port.should.equal('');
+      result.secure.should.be.true;
+    });
+  });
 });

--- a/test/lib/url.js
+++ b/test/lib/url.js
@@ -1,0 +1,24 @@
+/* eslint no-unused-expressions: 0 */
+
+const url = require('../../lib/url');
+
+describe('validation', () => {
+	describe('#parseURL', function() {
+		it('should return an object with host, port, and secure keys', function() {
+			let result = url.parseURL('http://localhost:3000');
+			result.host.should.equal('localhost');
+			result.port.should.equal('3000');
+			result.secure.should.be.false;
+
+			result = url.parseURL('https://localhost');
+			result.host.should.equal('localhost');
+			result.port.should.equal('');
+			result.secure.should.be.true;
+
+			result = url.parseURL('https://example.com:12345');
+			result.host.should.equal('example.com');
+			result.port.should.equal('12345');
+			result.secure.should.be.true;
+		});
+	});
+});


### PR DESCRIPTION
## Overview

Normally, when we specify the host of an API, we do so like this:

```
{
    "host": "example.com",
    "port": 1234,
    "secure": false
}
```

If we specify both the protocol and the port in the `host` variable, it makes the sdk behave in unexpected ways. For example:

```
{
    "host": "http://example.com:1234"
    // secure is true by default
}
```

All the requests would go to `https://http://example.com:1234:443`.

Using Node's `url` module, we parse the url, and if a protocol/port are found, we override the default ones.

```
// input:
{
    "host": "http://example.com:1234"
}

// output:
{
    "host": "example.com",
    "port": 1234,
    "secure": false
}
```

This change is made with backward compatibility in mind. If the host we provide is just the hostname, the sdk behaves like normal.

## Flaws

If we specify a host with a port but not a protocol:

```
{
    "host": "example.com:1234"
}
```

Node's url parser thinks the protocol is `example.com:` and that the hostname is `''`, which would default to `localhost`.

## Todo

- [ ] If a host is provided with a port but not a protocol, should we prepend the protocol to the host based on the `secure` flag?