### PR TITLE
Use retry/exponential backoff mechanisms for rawStream requests

### DIFF
--- a/history.md
+++ b/history.md
@@ -1,3 +1,7 @@
+# v1.4.11 - 2020/04/14
+
+* Use retry/exponential backoff mechanisms for rawStream requests.
+
 # v1.4.9 - 2020/02/27
 
 * Added backoff mechanism to any request called with setting totalTimeout.

--- a/lib/request.js
+++ b/lib/request.js
@@ -138,16 +138,17 @@ module.exports = (function (self) {
 	}
 
 	function isRetry(options, startTime, tryCount) {
+		// if totalTimeout isn't provided, we don't want to retry
+		if (!options.totalTimeout) {
+			return false;
+		}
+
 		if (tryCount > options.maxRetries) {
 			return false;
 		}
 
-		if (options.totalTimeout) {
-			const timeElapsed = (new Date()) - startTime;
-			return timeElapsed < options.totalTimeout;
-		}
-		
-		return true;
+		const timeElapsed = new Date() - startTime;
+		return timeElapsed < options.totalTimeout;
 	}
 
 	function Request (settings) {
@@ -293,6 +294,19 @@ module.exports = (function (self) {
 										HTTP_REDIRECT_NEW_CODE_TEMP
 									].some((code) => (code === context.statusCode));
 
+								const retry = context.statusCode >= HTTP_ERROR_CODE_RETRY_THRESHHOLD
+									&& isRetry(options, startTime, tryCount);
+
+								// handle retry if error code is above threshhold
+								if (retry) {
+									return delay(retryWait)
+										.then(() => {
+											tryCount++;
+											retryWait *= EXPONENT;
+										})
+										.then(makeRequest);
+								}
+
 								// provide response event (as there are response headers)
 								if (_this.emit) {
 									_this.emit(EVENT_RESPONSE, context);
@@ -368,18 +382,6 @@ module.exports = (function (self) {
 
 								res.once('end', () => {
 									let body = chunks.join('');
-									const retry = context.statusCode >= HTTP_ERROR_CODE_RETRY_THRESHHOLD
-										&& isRetry(options, startTime, tryCount);
-
-									// handle retry if error code is above threshhold
-									if (retry) {
-										tryCount += 1;
-										return delay(retryWait)
-											.then(makeRequest)
-											.then(() => {
-												retryWait *= EXPONENT;
-											});
-									}
 
 									// attempt to parse the body
 									if (typeof body === 'string' && body.length) {
@@ -417,12 +419,12 @@ module.exports = (function (self) {
 						req.on('error', (err) => {
 							// retry if below retry count threshhold
 							if (isRetry(options, startTime, tryCount)) {
-								tryCount += 1;
 								return delay(retryWait)
-									.then(makeRequest)
 									.then(() => {
+										tryCount++;
 										retryWait *= EXPONENT;
-									});
+									})
+									.then(makeRequest);
 							}
 
 							return reject(err)

--- a/lib/request.js
+++ b/lib/request.js
@@ -138,17 +138,16 @@ module.exports = (function (self) {
 	}
 
 	function isRetry(options, startTime, tryCount) {
-		// if totalTimeout isn't provided, we don't want to retry
-		if (!options.totalTimeout) {
-			return false;
-		}
-
 		if (tryCount > options.maxRetries) {
 			return false;
 		}
 
-		const timeElapsed = new Date() - startTime;
-		return timeElapsed < options.totalTimeout;
+		if (options.totalTimeout) {
+			const timeElapsed = new Date() - startTime;
+			return timeElapsed < options.totalTimeout;
+		}
+
+		return true;
 	}
 
 	function Request (settings) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "playnetwork-sdk",
-  "version": "1.4.10",
+  "version": "1.4.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playnetwork-sdk",
-  "version": "1.4.10",
+  "version": "1.4.11",
   "contributors": [
     {
       "name": "Joshua Thomas",


### PR DESCRIPTION
For requests where `options.rawStream` is set to `true`, the retry/exponential backoff weren't being triggered when the request failed.